### PR TITLE
Handle extra small screen sizes

### DIFF
--- a/lib/scalingUtils.js
+++ b/lib/scalingUtils.js
@@ -2,11 +2,17 @@ import { Dimensions } from 'react-native';
 const { width, height } = Dimensions.get('window');
 
 //Guideline sizes are based on standard ~5" screen mobile device
+//Guideline sizes are based on standard ~5" screen mobile device
 const guidelineBaseWidth = 350;
 const guidelineBaseHeight = 680;
 
-const scale = size => width / guidelineBaseWidth * size;
-const verticalScale = size => height / guidelineBaseHeight * size;
-const moderateScale = (size, factor = 0.5) => size + ( scale(size) - size ) * factor;
+const widthRatio = width / guidelineBaseWidth;
+const heightRatio = height / guidelineBaseHeight;
 
+const scale = size => widthRatio * size;
+const verticalScale = size => heightRatio * size;
+const moderateScaleNormal = (size, factor = 0.5) => size + ( scale(size) - size ) * factor;
+const moderateScaleExtraSmall = (size, factor = 0.5) => width / moderateScaleNormal(size, factor) * width;
+
+const moderateScale = widthRatio < 1 ? moderateScaleExtraSmall : moderateScaleNormal;
 export {scale, verticalScale, moderateScale};


### PR DESCRIPTION
Added a proposed fix for issue #4 

This should handle the smaller than reference screen sizes by normalizing the outputs inside screen bounds values..

However, please note that if the supplied size is bigger than the device width, instead of growing, the size will decrease.. 