### PR TITLE
Set scaling based on smallest dimension

### DIFF
--- a/lib/scalingUtils.js
+++ b/lib/scalingUtils.js
@@ -1,12 +1,13 @@
 import { Dimensions } from 'react-native';
 const { width, height } = Dimensions.get('window');
+const [w, h] = width > height ? [height, width] : [width, height];
 
 //Guideline sizes are based on standard ~5" screen mobile device
 const guidelineBaseWidth = 350;
 const guidelineBaseHeight = 680;
 
-const scale = size => width / guidelineBaseWidth * size;
-const verticalScale = size => height / guidelineBaseHeight * size;
+const scale = size => w / guidelineBaseWidth * size;
+const verticalScale = size => h / guidelineBaseHeight * size;
 const moderateScale = (size, factor = 0.5) => size + ( scale(size) - size ) * factor;
 
 export {scale, verticalScale, moderateScale};


### PR DESCRIPTION
This allows it so that scaling is done based on the smallest dimention
being the width.

This fixes the issue that makes it so that rendering isn't overly large
when rendering on landscape and changing to portrait or overly small on
the inverse orientation change.

Fixes the issue I found in #14.