### PR TITLE
Change default guideline (no dotenv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ const styles = ScaledSheet.create({
 ```
 
 ## Changing the Default Guideline Sizes
-
 In the ever-changing mobile devices world, screen sizes change a lot.  
 This lib uses 350dp x 680dp as guideline sizes, but if you (or your designer) prefer using different sizes it's possible.
 
-To do so, first, you'd need to setup [react-native-dotenv](https://github.com/zetachang/react-native-dotenv).  
+### Using react-native-dotenv
+First, you need to setup [react-native-dotenv](https://github.com/zetachang/react-native-dotenv).  
 After setting it up and creating `.env` file, add the following env params to it:
 ```env
 SIZE_MATTERS_BASE_WIDTH=<custom-width>
@@ -103,6 +103,14 @@ Next and final step, you should change all your imports to `react-native-size-ma
 ```javascript
 import { ScaledSheet, moderateScale } from 'react-native-size-matters/extend';
 ```
+### Without react-native-dotenv
+You can use the method `setBaseWidthAndHeight` to alter the guideline base width and height. Make sure you do it in you App.js or the first entry point of your app
+```
+import { setBaseWidthAndHeight } from 'react-native-size-matters';
+
+setBaseWidthAndHeight(375, 812);
+```
+
 
 ## Examples
 You can clone the [expo-example-app](./examples/expo-example-app) from this repo, run `npm install` and `npm start` and scan the presented QR code in the [Expo app](https://expo.io) on your preferred device.  

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ declare module "react-native-size-matters" {
         translateY?: string | number;
     }
 
+    export function setBaseWidthAndHeight(baseWidth: number, baseHeight: number): void;
     export function scale(size: number): number;
     export function verticalScale(size: number): number;
     export function moderateScale(size: number, factor?: number): number;

--- a/lib/scaling-utils.js
+++ b/lib/scaling-utils.js
@@ -4,9 +4,13 @@ const { width, height } = Dimensions.get('window');
 const [shortDimension, longDimension] = width < height ? [width, height] : [height, width];
 
 //Default guideline sizes are based on standard ~5" screen mobile device
-const guidelineBaseWidth = 350;
-const guidelineBaseHeight = 680;
+let guidelineBaseWidth = 350;
+let guidelineBaseHeight = 680;
 
+export const setBaseWidthAndHeight = (baseWidth, baseHeight) => {
+    guidelineBaseWidth = baseWidth;
+    guidelineBaseHeight = baseHeight;
+}
 export const scale = size => shortDimension / guidelineBaseWidth * size;
 export const verticalScale = size => longDimension / guidelineBaseHeight * size;
 export const moderateScale = (size, factor = 0.5) => size + ( scale(size) - size ) * factor;


### PR DESCRIPTION
### Overview
Currently the library allows updating the guideline base width and height, but it requires `react-native-dotenv` to be setup. However, for projects that do not use this dependency it seems like an overhead. This PR exposes a method to set the base guideline width and height which can be directly called from JS to manually set new guidelines.