### PR TITLE
Optional scaling

### DIFF
--- a/extend.d.ts
+++ b/extend.d.ts
@@ -12,7 +12,7 @@ declare module "react-native-size-matters/extend" {
     export function mvs(size: number, factor?: number): number;
 
     export namespace ScaledSheet {
-        export function create<T extends NamedStyles<T> | NamedStyles<any>>(stylesObject: T): {
+        export function create<T extends NamedStyles<T> | NamedStyles<any>>(stylesObject: T, disableScaling?: boolean): {
             [P in keyof T]: RN.RegisteredStyle<T[P] & Record<Extract<keyof T[P], keyof StringifiedStyles>, number>>
         };
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ declare module "react-native-size-matters" {
     type NamedStyles<T> = { [P in keyof T]: RN.ViewStyle | RN.TextStyle | RN.ImageStyle | StringifiedStyles };
 
     export namespace ScaledSheet {
-        export function create<T extends NamedStyles<T> | NamedStyles<any>>(stylesObject: T): {
+        export function create<T extends NamedStyles<T> | NamedStyles<any>>(stylesObject: T, disableScaling?: boolean): {
             [P in keyof T]: RN.RegisteredStyle<T[P] & Record<Extract<keyof T[P], keyof StringifiedStyles>, number>>
         };
     }

--- a/lib/ScaledSheet.js
+++ b/lib/ScaledSheet.js
@@ -5,7 +5,7 @@ import deepMap from './deep-map';
 //                             1                      2    3
 const validScaleSheetRegex = /^(\-?\d+(?:\.\d{1,3})?)@(mv?s(\d+(?:\.\d{1,2})?)?|s|vs)r?$/;
 
-const scaleByAnnotation = (scale, verticalScale, moderateScale, moderateVerticalScale) => (value) => {
+const scaleByAnnotation = (scale, verticalScale, moderateScale, moderateVerticalScale) => (value, disableScaling) => {
     if (!validScaleSheetRegex.test(value)) {
         return value;
     }
@@ -15,6 +15,10 @@ const scaleByAnnotation = (scale, verticalScale, moderateScale, moderateVertical
     const size = parseFloat(regexExecResult[1]);
     let scaleFunc = regexExecResult[2];
     const scaleFactor = regexExecResult[3]; // string or undefined
+
+    if (disableScaling) {
+        return size;
+    }
 
     if (scaleFactor)
         scaleFunc = scaleFunc.slice(0, - scaleFactor.length); // Remove the factor from it
@@ -44,7 +48,7 @@ const scaleByAnnotation = (scale, verticalScale, moderateScale, moderateVertical
 const scaledSheetCreator = (scale, verticalScale, moderateScale, moderateVerticalScale) => {
     const scaleFunc = scaleByAnnotation(scale, verticalScale, moderateScale, moderateVerticalScale);
     return {
-        create: styleSheet => StyleSheet.create(deepMap(styleSheet, scaleFunc))
+        create: (styleSheet, disableScaling) => StyleSheet.create(deepMap(styleSheet, (value) => scaleFunc(value, disableScaling)))
     };
 };
 


### PR DESCRIPTION
Greetings, colleagues 

First of all, I would like to say a huge thanks for creating and maintaining such a usefull solution!

For my project, I've found it useful to have optional scaling (e.g. to support scaling only on some limited list of devices).

My implementation could be quite naive, but it is just another shouldScale flag as a second parameter of create function.

The example of usage:

```
import DeviceInfo from 'react-native-device-info';
import { NamedStyles, ScaledSheet } from 'react-native-size-matters';

export const StyleSheet = {
  create: (styleSheet: NamedStyles<T>) => ScaledSheet.create(styleSheet, !DeviceInfo.isTablet()),
};
```

I do not insist on merging, but, mb, you'll find it more or less ok.

